### PR TITLE
send avatar URL to discourse

### DIFF
--- a/public/class-pt-wp-discourse-sso.php
+++ b/public/class-pt-wp-discourse-sso.php
@@ -349,6 +349,12 @@ class WP_Discourse_SSO {
 	private function restorePayload($p){
 		return urldecode( str_replace( '%0B', '%0A', urlencode( $p ) ) );
 	}
+	
+	private function get_avatar_url($user_id) {
+		$avatar = get_avatar($user_id);
+		if(preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
+			return utf8_uri_encode($matches[1]);
+	}
 
 	/**
 	 * Callback function to intercept and validate SSO requests
@@ -411,7 +417,8 @@ class WP_Discourse_SSO {
 					'username' => $current_user->user_login,
 					'email' => $current_user->user_email,
 					'about_me' => $current_user->description,
-					'external_id' => $current_user->ID
+					'external_id' => $current_user->ID,
+					'avatar_url' => self::get_avatar_url($current_user->ID)
 				);
 
 				// Build login string


### PR DESCRIPTION
If user has specified an avatar (usually gravatar) in their wordpress profile, send the URL for the avatar to Discourse.

Not sure exactly how useful this really is since Discourse can already directly pull in gravatars based on the user's email address and 99% of WP avatars are gravatars, but there are some WP plugins that let users create/manage their own avatar separate from gravatar and presumably, this should put the URL for whatever avatar is in use into the SSO payload.
