### PR TITLE
Added an integration for MemberMouse, Added Better Logout Syncing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === PrimeTime WordPress + Discourse SSO ===
-Contributors: etcio, nphaskins
+Contributors: etcio, nphaskins, dphrag
 Tags: discourse, forum, sso
 Requires at least: 3.6
-Tested up to: 4.1
-Stable tag: 0.2.3
+Tested up to: 4.3.1
+Stable tag: 0.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,7 @@ Some Features:
 
 *   Seamless integration into almost any WordPress installation.
 *   Get setup within minutes through 3 easy steps. Anyone can do it.
+*   Additional integration with MemberMouse.
 
 Coming Soon:
 
@@ -79,6 +80,10 @@ That's it!
 * SSO methods adapted from ArmedGuy : https://github.com/ArmedGuy/discourse_sso_php
 
 == Changelog ==
+
+= 0.2.4 =
+* Added basic support for MemberMouse
+* Added option to synchronize logouts, if user logging out from WP site.
 
 = 0.2.3 =
 * Send avatars to discourse (Thanks @pjv https://github.com/PrimeTimeCode/pt-wp-discourse-sso/pull/1)

--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === PrimeTime WordPress + Discourse SSO ===
-Contributors: etcio, nphaskins, dphrag
+Contributors: etcio, nphaskins
 Tags: discourse, forum, sso
 Requires at least: 3.6
-Tested up to: 4.3.1
-Stable tag: 0.2.4
+Tested up to: 4.1
+Stable tag: 0.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,7 +21,6 @@ Some Features:
 
 *   Seamless integration into almost any WordPress installation.
 *   Get setup within minutes through 3 easy steps. Anyone can do it.
-*   Additional integration with MemberMouse.
 
 Coming Soon:
 
@@ -80,10 +79,6 @@ That's it!
 * SSO methods adapted from ArmedGuy : https://github.com/ArmedGuy/discourse_sso_php
 
 == Changelog ==
-
-= 0.2.4 =
-* Added basic support for MemberMouse
-* Added option to synchronize logouts, if user logging out from WP site.
 
 = 0.2.3 =
 * Send avatars to discourse (Thanks @pjv https://github.com/PrimeTimeCode/pt-wp-discourse-sso/pull/1)

--- a/admin/includes/class.settings.php
+++ b/admin/includes/class.settings.php
@@ -1,135 +1,178 @@
 <?php
 /**
-* creates setting tabs
-*
-* @since version 1.0
-* @param null
-* @return global settings
-*/
+ * creates setting tabs
+ *
+ * @since version 1.0
+ * @param null
+ * @return global settings
+ */
 
-require_once dirname( __FILE__ ) . '/class.settings-api.php';
+require_once dirname(__FILE__) . '/class.settings-api.php';
 
-if ( !class_exists('pt_wp_discourse_sso_settings_api_wrap' ) ):
-class pt_wp_discourse_sso_settings_api_wrap {
+if (!class_exists('pt_wp_discourse_sso_settings_api_wrap')):
+	class pt_wp_discourse_sso_settings_api_wrap {
 
-    private $settings_api;
+		private $settings_api;
 
-    const version = '1.0';
+		const version = '1.0';
 
-    function __construct() {
+		function __construct() {
 
-        $this->dir  		= plugin_dir_path( __FILE__ );
-        $this->url  		= plugins_url( '', __FILE__ );
-        $this->settings_api = new WeDevs_Settings_API;
+			$this->dir = plugin_dir_path(__FILE__);
+			$this->url = plugins_url('', __FILE__);
+			$this->settings_api = new WeDevs_Settings_API;
 
-        add_action( 'admin_init', 					array($this, 'admin_init') );
-        add_action( 'admin_menu', 					array($this,'sub_menu_page'));
+			add_action('admin_init', array($this, 'admin_init'));
+			add_action('admin_menu', array($this, 'sub_menu_page'));
 
-    }
+		}
 
-    function admin_init() {
+		function admin_init() {
 
-        //set the settings
-        $this->settings_api->set_sections( $this->get_settings_sections() );
-        $this->settings_api->set_fields( $this->get_settings_fields() );
+			//set the settings
+			$this->settings_api->set_sections($this->get_settings_sections());
+			$this->settings_api->set_fields($this->get_settings_fields());
 
-        //initialize settings
-        $this->settings_api->admin_init();
-    }
+			//initialize settings
+			$this->settings_api->admin_init();
+		}
 
-	function sub_menu_page() {
-		add_submenu_page( 'options-general.php', 'PrimeTime WP + Discourse SSO Settings', __('WP Discourse SSO','pt-wp-discourse-sso'), 'manage_options', 'wp-sso-settings', array($this,'submenu_page_callback') );
-	}
+		function sub_menu_page() {
+			add_submenu_page('options-general.php', 'PrimeTime WP + Discourse SSO Settings', __('WP Discourse SSO', 'pt-wp-discourse-sso'), 'manage_options', 'wp-sso-settings', array($this, 'submenu_page_callback'));
+		}
 
 
-	function submenu_page_callback() {
+		function submenu_page_callback() {
 
-		echo '<div class="wrap">';
-			?><h2><?php _e('PrimeTime WP + Discourse SSO Settings','pt-wp-discourse-sso');?></h2><?php
+			echo '<div class="wrap">';
+			?><h2><?php _e('PrimeTime WP + Discourse SSO Settings', 'pt-wp-discourse-sso'); ?></h2><?php
 
 			$this->settings_api->show_navigation();
-        	$this->settings_api->show_forms();
+			$this->settings_api->show_forms();
 
-		echo '</div>';
-
-	}
-
-    function get_settings_sections() {
-        $sections = array(
-            array(
-                'id' 	=> 'pt_wp_sso_settings',
-                'title' => 'Discourse Settings'
-            )
-        );
-        return $sections;
-    }
-
-    function get_settings_fields() {
-
-        $settings_fields = array(
-            'pt_wp_sso_settings' => array(
-            	array(
-                    'name' 				=> 'secret_key',
-                    'label' 			=> 'Secret Key',
-                    'desc' 				=> 'Random string that will be the same on both your WP and Discourse installation.',
-                    'type' 				=> 'text',
-                    'default' 			=> '',
-                    'sanitize_callback' => 'sanitize_text_field'
-                ),
-                 array(
-                    'name' 				=> 'discourse_url',
-                    'label' 			=> 'Discourse URL',
-                    'desc' 				=> 'The base URL to your Discourse installation (include protocol)',
-                    'type' 				=> 'text',
-                    'default' 			=> '',
-                    'sanitize_callback' => 'sanitize_text_field'
-                )
-            )
-        );
-
-        return $settings_fields;
-    }
-
-    /**
-    *
-    *	Sanitize checkbox input
-    *
-    */
-    function sanitize_checkbox( $input ) {
-
-		if ( $input ) {
-
-			$output = '1';
-
-		} else {
-
-			$output = false;
+			echo '</div>';
 
 		}
 
-		return $output;
-	}
+		function get_settings_sections() {
+			$sections = array(
+				array(
+					'id' => 'pt_wp_sso_settings',
+					'title' => 'Discourse Settings'
+				)
+			);
 
-	/**
-	*
-	*	Sanitize integers
-	*
-	*/
-	function sanitize_int( $input ) {
-
-		if ( $input ) {
-
-			$output = absint( $input );
-
-		} else {
-
-			$output = false;
-
+			if (is_plugin_active('membermouse/index.php')) {
+				$sections[] = array(
+					'id' => 'pt_wp_sso_mm_settings',
+					'title' => 'Membermouse Settings'
+				);
+			}
+			return $sections;
 		}
 
-		return $output;
+		function get_settings_fields() {
+
+			$settings_fields = array(
+				'pt_wp_sso_settings' => array(
+					array(
+						'name' => 'secret_key',
+						'label' => 'Secret Key',
+						'desc' => 'Random string that will be the same on both your WP and Discourse installation.',
+						'type' => 'text',
+						'default' => '',
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					array(
+						'name' => 'discourse_url',
+						'label' => 'Discourse URL',
+						'desc' => 'The base URL to your Discourse installation (include protocol)',
+						'type' => 'text',
+						'default' => '',
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					array(
+						'name' => 'sync_logout',
+						'label' => 'Synchronize Logout',
+						'desc' => 'If user logs out of WP, also log them out of your Discourse installation',
+						'type' => 'checkbox',
+						'default' => 'off',
+						'sanitize_callback' => 'sanitize_checkbox'
+					),
+					array(
+						'name' => 'api_key',
+						'label' => 'Admin API Key',
+						'desc' => 'Required to synchronize logout',
+						'type' => 'text',
+						'default' => '',
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					array(
+						'name' => 'api_username',
+						'label' => 'Admin Username',
+						'desc' => 'Required to synchronize logout',
+						'type' => 'text',
+						'default' => '',
+						'sanitize_callback' => 'sanitize_text_field'
+					)
+				)
+			);
+
+			//If Membermouse is present, add option to disallow free members.
+			if (is_plugin_active('membermouse/index.php')) {
+				$settings_fields['pt_wp_sso_mm_settings'] = array(array(
+					'name' => 'block_membermouse_free',
+					'label' => 'Disallow Free Members',
+					'desc' => 'Block free MemberMouse members from accessing your Discourse installation.',
+					'type' => 'checkbox',
+					'default' => 'off',
+					'sanitize_callback' => 'sanitize_checkbox'
+				));
+			};
+
+			return $settings_fields;
+		}
+
+		/**
+		 *
+		 *    Sanitize checkbox input
+		 *
+		 */
+		function sanitize_checkbox($input) {
+
+			if ($input) {
+
+				$output = '1';
+
+			} else {
+
+				$output = false;
+
+			}
+
+			return $output;
+		}
+
+		/**
+		 *
+		 *    Sanitize integers
+		 *
+		 */
+		function sanitize_int($input) {
+
+			if ($input) {
+
+				$output = absint($input);
+
+			} else {
+
+				$output = false;
+
+			}
+
+			return $output;
+		}
 	}
-}
 endif;
 
 $settings = new pt_wp_discourse_sso_settings_api_wrap();

--- a/admin/includes/class.settings.php
+++ b/admin/includes/class.settings.php
@@ -61,6 +61,13 @@ class pt_wp_discourse_sso_settings_api_wrap {
                 'title' => 'Discourse Settings'
             )
         );
+
+        if (is_plugin_active('membermouse/index.php')) {
+            $sections[] = array (
+                'id' 	=> 'pt_wp_sso_mm_settings',
+                'title' => 'Membermouse Settings'
+            );
+        }
         return $sections;
     }
 
@@ -76,16 +83,52 @@ class pt_wp_discourse_sso_settings_api_wrap {
                     'default' 			=> '',
                     'sanitize_callback' => 'sanitize_text_field'
                 ),
-                 array(
+                array(
                     'name' 				=> 'discourse_url',
                     'label' 			=> 'Discourse URL',
                     'desc' 				=> 'The base URL to your Discourse installation (include protocol)',
                     'type' 				=> 'text',
                     'default' 			=> '',
                     'sanitize_callback' => 'sanitize_text_field'
+                ),
+                array(
+                    'name' 				=> 'sync_logout',
+                    'label' 			=> 'Synchronize Logout',
+                    'desc' 				=> 'If user logs out of WP, also log them out of your Discourse installation',
+                    'type' 				=> 'checkbox',
+                    'default' 			=> 'off',
+                    'sanitize_callback' => 'sanitize_checkbox'
+                ),
+                array(
+                    'name' 				=> 'api_key',
+                    'label' 			=> 'Admin API Key',
+                    'desc' 				=> 'Required to synchronize logout',
+                    'type' 				=> 'text',
+                    'default' 			=> '',
+                    'sanitize_callback' => 'sanitize_text_field'
+                ),
+                array(
+                    'name' 				=> 'api_username',
+                    'label' 			=> 'Admin Username',
+                    'desc' 				=> 'Required to synchronize logout',
+                    'type' 				=> 'text',
+                    'default' 			=> '',
+                    'sanitize_callback' => 'sanitize_text_field'
                 )
             )
         );
+
+        //If Membermouse is present, add option to disallow free members.
+        if (is_plugin_active('membermouse/index.php')) {
+            $settings_fields['pt_wp_sso_mm_settings'] = array(array(
+                    'name' 				=> 'block_membermouse_free',
+                    'label' 			=> 'Disallow Free Members',
+                    'desc' 				=> 'Block free MemberMouse members from accessing your Discourse installation.',
+                    'type' 				=> 'checkbox',
+                    'default' 			=> 'off',
+                    'sanitize_callback' => 'sanitize_checkbox'
+            ));
+        };
 
         return $settings_fields;
     }

--- a/admin/includes/class.settings.php
+++ b/admin/includes/class.settings.php
@@ -61,13 +61,6 @@ class pt_wp_discourse_sso_settings_api_wrap {
                 'title' => 'Discourse Settings'
             )
         );
-
-        if (is_plugin_active('membermouse/index.php')) {
-            $sections[] = array (
-                'id' 	=> 'pt_wp_sso_mm_settings',
-                'title' => 'Membermouse Settings'
-            );
-        }
         return $sections;
     }
 
@@ -83,52 +76,16 @@ class pt_wp_discourse_sso_settings_api_wrap {
                     'default' 			=> '',
                     'sanitize_callback' => 'sanitize_text_field'
                 ),
-                array(
+                 array(
                     'name' 				=> 'discourse_url',
                     'label' 			=> 'Discourse URL',
                     'desc' 				=> 'The base URL to your Discourse installation (include protocol)',
                     'type' 				=> 'text',
                     'default' 			=> '',
                     'sanitize_callback' => 'sanitize_text_field'
-                ),
-                array(
-                    'name' 				=> 'sync_logout',
-                    'label' 			=> 'Synchronize Logout',
-                    'desc' 				=> 'If user logs out of WP, also log them out of your Discourse installation',
-                    'type' 				=> 'checkbox',
-                    'default' 			=> 'off',
-                    'sanitize_callback' => 'sanitize_checkbox'
-                ),
-                array(
-                    'name' 				=> 'api_key',
-                    'label' 			=> 'Admin API Key',
-                    'desc' 				=> 'Required to synchronize logout',
-                    'type' 				=> 'text',
-                    'default' 			=> '',
-                    'sanitize_callback' => 'sanitize_text_field'
-                ),
-                array(
-                    'name' 				=> 'api_username',
-                    'label' 			=> 'Admin Username',
-                    'desc' 				=> 'Required to synchronize logout',
-                    'type' 				=> 'text',
-                    'default' 			=> '',
-                    'sanitize_callback' => 'sanitize_text_field'
                 )
             )
         );
-
-        //If Membermouse is present, add option to disallow free members.
-        if (is_plugin_active('membermouse/index.php')) {
-            $settings_fields['pt_wp_sso_mm_settings'] = array(array(
-                    'name' 				=> 'block_membermouse_free',
-                    'label' 			=> 'Disallow Free Members',
-                    'desc' 				=> 'Block free MemberMouse members from accessing your Discourse installation.',
-                    'type' 				=> 'checkbox',
-                    'default' 			=> 'off',
-                    'sanitize_callback' => 'sanitize_checkbox'
-            ));
-        };
 
         return $settings_fields;
     }

--- a/public/class-pt-wp-discourse-sso.php
+++ b/public/class-pt-wp-discourse-sso.php
@@ -19,419 +19,469 @@
  */
 class WP_Discourse_SSO {
 
-	public $configured = array();
-	private $sso_secret;
-	public $discourse_url;
-	public $admin_url;
+    public $configured = array();
+    private $sso_secret;
+    public $discourse_url;
+    public $admin_url;
 
-	/**
-	 * Plugin version, used for cache-busting of style and script file references.
-	 *
-	 * @since   0.1
-	 *
-	 * @var     string
-	 */
-	const VERSION = PT_WP_DISCOURSE_SSO_VERSION;
+    /**
+     * Plugin version, used for cache-busting of style and script file references.
+     *
+     * @since   0.1
+     *
+     * @var     string
+     */
+    const VERSION = PT_WP_DISCOURSE_SSO_VERSION;
 
-	/**
-	 * Unique identifier
-	 *
-	 *
-	 * The variable name is used as the text domain when internationalizing strings
-	 * of text. Its value should match the Text Domain file header in the main
-	 * plugin file.
-	 *
-	 * @since    0.1
-	 *
-	 * @var      string
-	 */
-	protected $plugin_slug = 'pt-wp-discourse-sso';
+    /**
+     * Unique identifier
+     *
+     *
+     * The variable name is used as the text domain when internationalizing strings
+     * of text. Its value should match the Text Domain file header in the main
+     * plugin file.
+     *
+     * @since    0.1
+     *
+     * @var      string
+     */
+    protected $plugin_slug = 'pt-wp-discourse-sso';
 
-	/**
-	 * Instance of this class.
-	 *
-	 * @since    0.1
-	 *
-	 * @var      object
-	 */
-	protected static $instance = null;
+    /**
+     * Instance of this class.
+     *
+     * @since    0.1
+     *
+     * @var      object
+     */
+    protected static $instance = null;
 
-	/**
-	 * Initialize the plugin by setting localization and loading public scripts
-	 * and styles.
-	 *
-	 * @since     0.1
-	 */
-	private function __construct() {
+    /**
+     * Initialize the plugin by setting localization and loading public scripts
+     * and styles.
+     *
+     * @since     0.1
+     */
+    private function __construct() {
 
-		// Activate plugin when new blog is added
-		add_action( 'wpmu_new_blog', array( $this, 'activate_new_site' ) );
+        // Activate plugin when new blog is added
+        add_action('wpmu_new_blog', array($this, 'activate_new_site'));
 
-		require_once(PT_WP_DISCOURSE_SSO_DIR.'public/includes/helpers.php');
+        require_once(PT_WP_DISCOURSE_SSO_DIR . 'public/includes/helpers.php');
 
-		$this->check_configuration();
+        $this->check_configuration();
 
-		$this->admin_url = admin_url('options-general.php?page=wp-sso-settings');
+        $this->admin_url = admin_url('options-general.php?page=wp-sso-settings');
 
-		add_action( 'init', array( $this, 'interceptSSORequest' ) );
+        add_action('init', array($this, 'interceptSSORequest'));
 
-	}
+        add_action('clear_auth_cookie', array($this, 'interceptLogout'));
 
-	private function check_configuration() {
-		$this->configured['all'] = FALSE;
-		$this->configured['secret'] = FALSE;
-		$this->configured['discourse_url'] = FALSE;
-		$this->configured['activated'] = FALSE;
+    }
 
-		if ( get_site_option( 'pt_wp_discourse_sso_activated' ) ) {
-			$this->configured['activated'] = TRUE;
-		}
-		
-		if ( NULL != pt_wp_sso_get_option('secret_key','pt_wp_sso_settings') ) {
-			$this->configured['secret'] = TRUE;
-			$this->sso_secret = pt_wp_sso_get_option('secret_key','pt_wp_sso_settings');
-		}
+    private function check_configuration() {
+        $this->configured['all'] = FALSE;
+        $this->configured['secret'] = FALSE;
+        $this->configured['discourse_url'] = FALSE;
+        $this->configured['activated'] = FALSE;
 
-		if ( NULL != pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings') ) {
-			$this->configured['discourse_url'] = TRUE;
-			$this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings'),'/');
-		}
+        if (get_site_option('pt_wp_discourse_sso_activated')) {
+            $this->configured['activated'] = TRUE;
+        }
 
-		// Make sure the plugin is configured
-		if ( $this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated'] ) {
-			$this->configured['all'] = TRUE;
-		}
+        if (NULL != pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings')) {
+            $this->configured['secret'] = TRUE;
+            $this->sso_secret = pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings');
+        }
 
-		if ( ! $this->configured['all'] ) {
-			add_action( 'admin_notices', array( $this, 'render_admin_notice' ) );
-		}
+        if (NULL != pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings')) {
+            $this->configured['discourse_url'] = TRUE;
+            $this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings'), '/');
+        }
 
-	}
+        // Make sure the plugin is configured
+        if ($this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated']) {
+            $this->configured['all'] = TRUE;
+        }
 
-	public function render_admin_notice() {
-		?>
-    <div class="error">
-			<h4>Setting up your WP + Discourse SSO connection is easy!</h4>
-			<p>
-			<ol>
-				<li><?php echo ($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['secret'] ? '</s>' : ''); ?></li>
-				<li><?php echo ($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL (http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
-				<li><?php echo ($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This message will go away once you'd validated your first SSO request)</i><?php echo ($this->configured['activated'] ? '</s>' : ''); ?></li>
-			</ol>
-			</p>
-    </div>
+        if (!$this->configured['all']) {
+            add_action('admin_notices', array($this, 'render_admin_notice'));
+        }
+
+    }
+
+    public function render_admin_notice() {
+        ?>
+        <div class="error">
+            <h4>Setting up your WP + Discourse SSO connection is easy!</h4>
+
+            <p>
+            <ol>
+                <li><?php echo($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of
+                    characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings
+                        page</a>.<?php echo($this->configured['secret'] ? '</s>' : ''); ?></li>
+                <li><?php echo($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL
+                    (http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings
+                        page</a>.<?php echo($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
+                <li><?php echo($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This
+                        message will go away once you'd validated your first SSO
+                        request)</i><?php echo($this->configured['activated'] ? '</s>' : ''); ?></li>
+            </ol>
+            </p>
+        </div>
     <?php
-	}
+    }
 
-	/**
-	 * Return the plugin slug.
-	 *
-	 * @since    0.1
-	 *
-	 * @return    Plugin slug variable.
-	 */
-	public function get_plugin_slug() {
-		return $this->plugin_slug;
-	}
+    /**
+     * Return the plugin slug.
+     *
+     * @since    0.1
+     *
+     * @return    Plugin slug variable.
+     */
+    public function get_plugin_slug() {
+        return $this->plugin_slug;
+    }
 
-	/**
-	 * Return an instance of this class.
-	 *
-	 * @since     0.1
-	 *
-	 * @return    object    A single instance of this class.
-	 */
-	public static function get_instance() {
+    /**
+     * Return an instance of this class.
+     *
+     * @since     0.1
+     *
+     * @return    object    A single instance of this class.
+     */
+    public static function get_instance() {
 
-		// If the single instance hasn't been set, set it now.
-		if ( null == self::$instance ) {
-			self::$instance = new self;
-		}
+        // If the single instance hasn't been set, set it now.
+        if (null == self::$instance) {
+            self::$instance = new self;
+        }
 
-		return self::$instance;
-	}
+        return self::$instance;
+    }
 
-	/**
-	 * Fired when the plugin is activated.
-	 *
-	 * @since    0.1
-	 *
-	 * @param    boolean    $network_wide    True if WPMU superadmin uses
-	 *                                       "Network Activate" action, false if
-	 *                                       WPMU is disabled or plugin is
-	 *                                       activated on an individual blog.
-	 */
-	public static function activate( $network_wide ) {
+    /**
+     * Fired when the plugin is activated.
+     *
+     * @since    0.1
+     *
+     * @param    boolean $network_wide True if WPMU superadmin uses
+     *                                       "Network Activate" action, false if
+     *                                       WPMU is disabled or plugin is
+     *                                       activated on an individual blog.
+     */
+    public static function activate($network_wide) {
 
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+        if (function_exists('is_multisite') && is_multisite()) {
 
-			if ( $network_wide  ) {
+            if ($network_wide) {
 
-				// Get all blog ids
-				$blog_ids = self::get_blog_ids();
+                // Get all blog ids
+                $blog_ids = self::get_blog_ids();
 
-				foreach ( $blog_ids as $blog_id ) {
+                foreach ($blog_ids as $blog_id) {
 
-					switch_to_blog( $blog_id );
-					self::single_activate();
-				}
+                    switch_to_blog($blog_id);
+                    self::single_activate();
+                }
 
-				restore_current_blog();
+                restore_current_blog();
 
-			} else {
-				self::single_activate();
-			}
+            } else {
+                self::single_activate();
+            }
 
-		} else {
-			self::single_activate();
-		}
+        } else {
+            self::single_activate();
+        }
 
-	}
+    }
 
-	/**
-	 * Fired when the plugin is deactivated.
-	 *
-	 * @since    0.1
-	 *
-	 * @param    boolean    $network_wide    True if WPMU superadmin uses
-	 *                                       "Network Deactivate" action, false if
-	 *                                       WPMU is disabled or plugin is
-	 *                                       deactivated on an individual blog.
-	 */
-	public static function deactivate( $network_wide ) {
+    /**
+     * Fired when the plugin is deactivated.
+     *
+     * @since    0.1
+     *
+     * @param    boolean $network_wide True if WPMU superadmin uses
+     *                                       "Network Deactivate" action, false if
+     *                                       WPMU is disabled or plugin is
+     *                                       deactivated on an individual blog.
+     */
+    public static function deactivate($network_wide) {
 
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+        if (function_exists('is_multisite') && is_multisite()) {
 
-			if ( $network_wide ) {
+            if ($network_wide) {
 
-				// Get all blog ids
-				$blog_ids = self::get_blog_ids();
+                // Get all blog ids
+                $blog_ids = self::get_blog_ids();
 
-				foreach ( $blog_ids as $blog_id ) {
+                foreach ($blog_ids as $blog_id) {
 
-					switch_to_blog( $blog_id );
-					self::single_deactivate();
+                    switch_to_blog($blog_id);
+                    self::single_deactivate();
 
-				}
+                }
 
-				restore_current_blog();
+                restore_current_blog();
 
-			} else {
-				self::single_deactivate();
-			}
+            } else {
+                self::single_deactivate();
+            }
 
-		} else {
-			self::single_deactivate();
-		}
+        } else {
+            self::single_deactivate();
+        }
 
-	}
+    }
 
-	/**
-	 * Fired when a new site is activated with a WPMU environment.
-	 *
-	 * @since    0.1
-	 *
-	 * @param    int    $blog_id    ID of the new blog.
-	 */
-	public function activate_new_site( $blog_id ) {
+    /**
+     * Fired when a new site is activated with a WPMU environment.
+     *
+     * @since    0.1
+     *
+     * @param    int $blog_id ID of the new blog.
+     */
+    public function activate_new_site($blog_id) {
 
-		if ( 1 !== did_action( 'wpmu_new_blog' ) ) {
-			return;
-		}
+        if (1 !== did_action('wpmu_new_blog')) {
+            return;
+        }
 
-		switch_to_blog( $blog_id );
-		self::single_activate();
-		restore_current_blog();
+        switch_to_blog($blog_id);
+        self::single_activate();
+        restore_current_blog();
 
-	}
+    }
 
-	/**
-	 * Get all blog ids of blogs in the current network that are:
-	 * - not archived
-	 * - not spam
-	 * - not deleted
-	 *
-	 * @since    0.1
-	 *
-	 * @return   array|false    The blog ids, false if no matches.
-	 */
-	private static function get_blog_ids() {
+    /**
+     * Get all blog ids of blogs in the current network that are:
+     * - not archived
+     * - not spam
+     * - not deleted
+     *
+     * @since    0.1
+     *
+     * @return   array|false    The blog ids, false if no matches.
+     */
+    private static function get_blog_ids() {
 
-		global $wpdb;
+        global $wpdb;
 
-		// get an array of blog ids
-		$sql = "SELECT blog_id FROM $wpdb->blogs
+        // get an array of blog ids
+        $sql = "SELECT blog_id FROM $wpdb->blogs
 			WHERE archived = '0' AND spam = '0'
 			AND deleted = '0'";
 
-		return $wpdb->get_col( $sql );
+        return $wpdb->get_col($sql);
 
-	}
+    }
 
-	/**
-	 * Fired for each blog when the plugin is activated.
-	 *
-	 * @since    0.1
-	 */
-	private static function single_activate() {
-		// @TODO: Define activation functionality here
-	}
+    /**
+     * Fired for each blog when the plugin is activated.
+     *
+     * @since    0.1
+     */
+    private static function single_activate() {
+        // @TODO: Define activation functionality here
+    }
 
-	/**
-	 * Fired for each blog when the plugin is deactivated.
-	 *
-	 * @since    0.1
-	 */
-	private static function single_deactivate() {
-		// @TODO: Define deactivation functionality here
-	}
+    /**
+     * Fired for each blog when the plugin is deactivated.
+     *
+     * @since    0.1
+     */
+    private static function single_deactivate() {
+        // @TODO: Define deactivation functionality here
+    }
 
-	/**
-	 * Validate the SSO payload
-	 * @param  [type] $payload [description]
-	 * @param  [type] $sig     [description]
-	 * @return [type]          [description]
-	 */
-	public function validate($payload, $sig) {
+    /**
+     * Validate the SSO payload
+     * @param  [type] $payload [description]
+     * @param  [type] $sig     [description]
+     * @return [type]          [description]
+     */
+    public function validate($payload, $sig) {
 
-		$payload = urldecode($payload);
-		if(hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
-			if( !$this->configured['activated'] ){
-				add_site_option( 'pt_wp_discourse_sso_activated', TRUE );
-			}
-			return true;
-		} else {
-			return false;
-		}
-	}
-	
-	/**
-	 * Get nonce out of original payload
-	 * @param  [type] $payload [description]
-	 * @return [type]          [description]
-	 */
-	public function getNonce($payload) {
-		$payload = urldecode($payload);
-		$query = array();
-		parse_str(base64_decode($payload), $query);
-		if(isset($query["nonce"])) {
-			return $query["nonce"];
-		} else {
-			throw new Exception("Nonce not found in payload!");
-		}
-	}
-	
-	/**
-	 * Create a login string to authenticate with Discourse
-	 * @param  [type] $params [description]
-	 * @return [type]         [description]
-	 */
-	public function buildLoginString($params) {
-		if(!isset($params["external_id"])) {
-			throw new Exception("Missing required parameter 'external_id'");
-		}
-		if(!isset($params["nonce"])) {
-			throw new Exception("Missing required parameter 'nonce'");
-		}
-		if(!isset($params["email"])) {
-			throw new Exception("Missing required parameter 'email'");
-		}
-		$payload = base64_encode(http_build_query($params));
-		$sig = hash_hmac("sha256", $payload, $this->sso_secret);
-		
-		return http_build_query(array("sso" => $payload, "sig" => $sig));
-	}
+        $payload = urldecode($payload);
+        if (hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
+            if (!$this->configured['activated']) {
+                add_site_option('pt_wp_discourse_sso_activated', TRUE);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	private function cleansePayload($p){
-		return str_replace( '%0A', '%0B', $p );
-	}
+    /**
+     * Get nonce out of original payload
+     * @param  [type] $payload [description]
+     * @return [type]          [description]
+     */
+    public function getNonce($payload) {
+        $payload = urldecode($payload);
+        $query = array();
+        parse_str(base64_decode($payload), $query);
+        if (isset($query["nonce"])) {
+            return $query["nonce"];
+        } else {
+            throw new Exception("Nonce not found in payload!");
+        }
+    }
 
-	private function restorePayload($p){
-		return urldecode( str_replace( '%0B', '%0A', urlencode( $p ) ) );
-	}
-	
-	private function get_avatar_url($user_id) {
-		$avatar = get_avatar($user_id);
-		if(preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
-			return utf8_uri_encode($matches[1]);
-	}
+    /**
+     * Create a login string to authenticate with Discourse
+     * @param  [type] $params [description]
+     * @return [type]         [description]
+     */
+    public function buildLoginString($params) {
+        if (!isset($params["external_id"])) {
+            throw new Exception("Missing required parameter 'external_id'");
+        }
+        if (!isset($params["nonce"])) {
+            throw new Exception("Missing required parameter 'nonce'");
+        }
+        if (!isset($params["email"])) {
+            throw new Exception("Missing required parameter 'email'");
+        }
+        $payload = base64_encode(http_build_query($params));
+        $sig = hash_hmac("sha256", $payload, $this->sso_secret);
 
-	/**
-	 * Callback function to intercept and validate SSO requests
-	 * @return [type] [description]
-	 */
-	public function interceptSSORequest() {
+        return http_build_query(array("sso" => $payload, "sig" => $sig));
+    }
 
-		if( isset( $_GET['sso'] ) && isset( $_GET['sig'] ) ) {
+    private function cleansePayload($p) {
+        return str_replace('%0A', '%0B', $p);
+    }
 
-			$varsso = $_GET['sso'];
-			$varsig = $_GET['sig'];
+    private function restorePayload($p) {
+        return urldecode(str_replace('%0B', '%0A', urlencode($p)));
+    }
 
-			if( ! $this->validate( $varsso, $varsig ) ) {
-				//return;
-			}
-			
-			// Check to see whether the user is logged in or not
-			if ( ! is_user_logged_in() ) {
+    private function get_avatar_url($user_id) {
+        $avatar = get_avatar($user_id);
+        if (preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
+            return utf8_uri_encode($matches[1]);
+    }
 
-				// Preserve sso and sig parameters
-				$redirect = add_query_arg( array( 'sso' => urlencode( $varsso ), 'sig' => urlencode( $varsig ) ) );
-				
-				// Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
-				$redirect = $this->cleansePayload( $redirect );
+    /**
+     * Callback function to intercept and validate SSO requests
+     * @return [type] [description]
+     */
+    public function interceptSSORequest() {
 
-				// Build login URL
-				$login = wp_login_url( esc_url_raw( $redirect ) );
+        if (isset($_GET['sso']) && isset($_GET['sig'])) {
 
-				// Redirect to login
-				wp_redirect( $login );
-				exit;
+            $varsso = $_GET['sso'];
+            $varsig = $_GET['sig'];
 
-			}
+            if (!$this->validate($varsso, $varsig)) {
+                //return;
+            }
 
-			// Logged in to WordPress, now try to log in to Discourse with WordPress user information
-			else {
+            // Check to see whether the user is logged in or not
+            if (!is_user_logged_in()) {
 
-				$ssopayload = $this->restorePayload( $_GET['sso'] );
-				$sigpayload = $_GET['sig'];
+                // Preserve sso and sig parameters
+                $redirect = add_query_arg(array('sso' => urlencode($varsso), 'sig' => urlencode($varsig)));
 
-				if ( ! ( $this->validate( $ssopayload, $sigpayload ) ) ) {
-					
-					// Error message
-					echo( 'Invalid request.' );
-					
-					// Terminate
-					exit;
+                // Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
+                $redirect = $this->cleansePayload($redirect);
 
-				}
+                // Build login URL
+                $login = wp_login_url(esc_url_raw($redirect));
 
-				// Nonce    
-				$nonce = $this->getNonce( $ssopayload );
+                // Redirect to login
+                wp_redirect($login);
+                exit;
 
-				$current_user = wp_get_current_user();
+            } // Logged in to WordPress, now try to log in to Discourse with WordPress user information
+            else {
+                $allowedToLogin = true;
+                if (is_plugin_active('membermouse/index.php')) {
+                    if (pt_wp_sso_get_option('block_membermouse_free', 'pt_wp_sso_mm_settings') == 'on') {
+                        if (mm_member_decision(array("isFree" => "true"))) {
+                            $allowedToLogin = false;
+                        }
+                    }
+                }
 
-				// Map information
-				$params = array(
-					'nonce' => $nonce,
-					'name' => $current_user->display_name,
-					'username' => $current_user->user_login,
-					'email' => $current_user->user_email,
-					'about_me' => $current_user->description,
-					'external_id' => $current_user->ID,
-					'avatar_url' => self::get_avatar_url($current_user->ID)
-				);
+                if ($allowedToLogin) {
+                    $ssopayload = $this->restorePayload($_GET['sso']);
+                    $sigpayload = $_GET['sig'];
 
-				// Build login string
-				$q = $this->buildLoginString( $params );
+                    if (!($this->validate($ssopayload, $sigpayload))) {
 
-				// Redirect back to Discourse
-				wp_redirect( $this->discourse_url . '/session/sso_login?' . $q );
+                        // Error message
+                        echo('Invalid request.');
 
-				exit;
+                        // Terminate
+                        exit;
 
-			}
-		}
-	}
+                    }
+
+                    // Nonce
+                    $nonce = $this->getNonce($ssopayload);
+
+                    $current_user = wp_get_current_user();
+
+                    // Map information
+                    $params = array(
+                        'nonce' => $nonce,
+                        'name' => $current_user->display_name,
+                        'username' => $current_user->user_login,
+                        'email' => $current_user->user_email,
+                        'about_me' => $current_user->description,
+                        'external_id' => $current_user->ID,
+                        'avatar_url' => self::get_avatar_url($current_user->ID)
+                    );
+
+                    // Build login string
+                    $q = $this->buildLoginString($params);
+
+                    // Redirect back to Discourse
+                    wp_redirect($this->discourse_url . '/session/sso_login?' . $q);
+                } else {
+                    //redirect to home
+                    wp_redirect(home_url());
+                }
+
+                exit;
+
+            }
+        }
+    }
+
+    //If sync logout is enabled, we need to find the user id, then log that user out of discourse.
+    public function interceptLogout() {
+        if (pt_wp_sso_get_option('sync_logout', 'pt_wp_sso_settings') == 'on') {
+            $api_key = pt_wp_sso_get_option('api_key', 'pt_wp_sso_settings');
+            $api_username = pt_wp_sso_get_option('api_username', 'pt_wp_sso_settings');
+
+            if (NULL != $api_key && NULL != $api_username) {
+                $userinfo = wp_get_current_user();
+
+                $params = '?api_key=' . $api_key . '&api_username=' . $api_username;
+                $get_url = $this->discourse_url . '/users/by-external/' . $userinfo->ID . '.json' . $params;
+
+                //First Talk to Discourse and get Discourse ID
+                $response = wp_safe_remote_get($get_url);
+
+                if ( is_array( $response ) && ! is_wp_error( $response ) ) {
+                    $body = json_decode($response['body'], true);
+                    $id = $body['user']['id'];
+                    if (NULL != $id) {
+                        //fire the logout trigger
+                        $post_url =  $this->discourse_url . '/admin/users/' . $id . '/log_out'. $params;
+                        $response = wp_safe_remote_post($post_url);
+                    }
+                }
+            }
+
+        }
+
+    }
 
 }
 

--- a/public/class-pt-wp-discourse-sso.php
+++ b/public/class-pt-wp-discourse-sso.php
@@ -65,15 +65,17 @@ class WP_Discourse_SSO {
 	private function __construct() {
 
 		// Activate plugin when new blog is added
-		add_action( 'wpmu_new_blog', array( $this, 'activate_new_site' ) );
+		add_action('wpmu_new_blog', array($this, 'activate_new_site'));
 
-		require_once(PT_WP_DISCOURSE_SSO_DIR.'public/includes/helpers.php');
+		require_once(PT_WP_DISCOURSE_SSO_DIR . 'public/includes/helpers.php');
 
 		$this->check_configuration();
 
 		$this->admin_url = admin_url('options-general.php?page=wp-sso-settings');
 
-		add_action( 'init', array( $this, 'interceptSSORequest' ) );
+		add_action('init', array($this, 'interceptSSORequest'));
+
+		add_action('clear_auth_cookie', array($this, 'interceptLogout'));
 
 	}
 
@@ -83,44 +85,51 @@ class WP_Discourse_SSO {
 		$this->configured['discourse_url'] = FALSE;
 		$this->configured['activated'] = FALSE;
 
-		if ( get_site_option( 'pt_wp_discourse_sso_activated' ) ) {
+		if (get_site_option('pt_wp_discourse_sso_activated')) {
 			$this->configured['activated'] = TRUE;
 		}
-		
-		if ( NULL != pt_wp_sso_get_option('secret_key','pt_wp_sso_settings') ) {
+
+		if (NULL != pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings')) {
 			$this->configured['secret'] = TRUE;
-			$this->sso_secret = pt_wp_sso_get_option('secret_key','pt_wp_sso_settings');
+			$this->sso_secret = pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings');
 		}
 
-		if ( NULL != pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings') ) {
+		if (NULL != pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings')) {
 			$this->configured['discourse_url'] = TRUE;
-			$this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings'),'/');
+			$this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings'), '/');
 		}
 
 		// Make sure the plugin is configured
-		if ( $this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated'] ) {
+		if ($this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated']) {
 			$this->configured['all'] = TRUE;
 		}
 
-		if ( ! $this->configured['all'] ) {
-			add_action( 'admin_notices', array( $this, 'render_admin_notice' ) );
+		if (!$this->configured['all']) {
+			add_action('admin_notices', array($this, 'render_admin_notice'));
 		}
 
 	}
 
 	public function render_admin_notice() {
 		?>
-    <div class="error">
+		<div class="error">
 			<h4>Setting up your WP + Discourse SSO connection is easy!</h4>
+
 			<p>
 			<ol>
-				<li><?php echo ($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['secret'] ? '</s>' : ''); ?></li>
-				<li><?php echo ($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL (http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
-				<li><?php echo ($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This message will go away once you'd validated your first SSO request)</i><?php echo ($this->configured['activated'] ? '</s>' : ''); ?></li>
+				<li><?php echo($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of
+					characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings
+						page</a>.<?php echo($this->configured['secret'] ? '</s>' : ''); ?></li>
+				<li><?php echo($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL
+					(http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings
+						page</a>.<?php echo($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
+				<li><?php echo($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This
+						message will go away once you'd validated your first SSO
+						request)</i><?php echo($this->configured['activated'] ? '</s>' : ''); ?></li>
 			</ol>
 			</p>
-    </div>
-    <?php
+		</div>
+	<?php
 	}
 
 	/**
@@ -144,7 +153,7 @@ class WP_Discourse_SSO {
 	public static function get_instance() {
 
 		// If the single instance hasn't been set, set it now.
-		if ( null == self::$instance ) {
+		if (null == self::$instance) {
 			self::$instance = new self;
 		}
 
@@ -156,23 +165,23 @@ class WP_Discourse_SSO {
 	 *
 	 * @since    0.1
 	 *
-	 * @param    boolean    $network_wide    True if WPMU superadmin uses
+	 * @param    boolean $network_wide True if WPMU superadmin uses
 	 *                                       "Network Activate" action, false if
 	 *                                       WPMU is disabled or plugin is
 	 *                                       activated on an individual blog.
 	 */
-	public static function activate( $network_wide ) {
+	public static function activate($network_wide) {
 
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if (function_exists('is_multisite') && is_multisite()) {
 
-			if ( $network_wide  ) {
+			if ($network_wide) {
 
 				// Get all blog ids
 				$blog_ids = self::get_blog_ids();
 
-				foreach ( $blog_ids as $blog_id ) {
+				foreach ($blog_ids as $blog_id) {
 
-					switch_to_blog( $blog_id );
+					switch_to_blog($blog_id);
 					self::single_activate();
 				}
 
@@ -193,23 +202,23 @@ class WP_Discourse_SSO {
 	 *
 	 * @since    0.1
 	 *
-	 * @param    boolean    $network_wide    True if WPMU superadmin uses
+	 * @param    boolean $network_wide True if WPMU superadmin uses
 	 *                                       "Network Deactivate" action, false if
 	 *                                       WPMU is disabled or plugin is
 	 *                                       deactivated on an individual blog.
 	 */
-	public static function deactivate( $network_wide ) {
+	public static function deactivate($network_wide) {
 
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if (function_exists('is_multisite') && is_multisite()) {
 
-			if ( $network_wide ) {
+			if ($network_wide) {
 
 				// Get all blog ids
 				$blog_ids = self::get_blog_ids();
 
-				foreach ( $blog_ids as $blog_id ) {
+				foreach ($blog_ids as $blog_id) {
 
-					switch_to_blog( $blog_id );
+					switch_to_blog($blog_id);
 					self::single_deactivate();
 
 				}
@@ -231,15 +240,15 @@ class WP_Discourse_SSO {
 	 *
 	 * @since    0.1
 	 *
-	 * @param    int    $blog_id    ID of the new blog.
+	 * @param    int $blog_id ID of the new blog.
 	 */
-	public function activate_new_site( $blog_id ) {
+	public function activate_new_site($blog_id) {
 
-		if ( 1 !== did_action( 'wpmu_new_blog' ) ) {
+		if (1 !== did_action('wpmu_new_blog')) {
 			return;
 		}
 
-		switch_to_blog( $blog_id );
+		switch_to_blog($blog_id);
 		self::single_activate();
 		restore_current_blog();
 
@@ -264,7 +273,7 @@ class WP_Discourse_SSO {
 			WHERE archived = '0' AND spam = '0'
 			AND deleted = '0'";
 
-		return $wpdb->get_col( $sql );
+		return $wpdb->get_col($sql);
 
 	}
 
@@ -295,16 +304,16 @@ class WP_Discourse_SSO {
 	public function validate($payload, $sig) {
 
 		$payload = urldecode($payload);
-		if(hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
-			if( !$this->configured['activated'] ){
-				add_site_option( 'pt_wp_discourse_sso_activated', TRUE );
+		if (hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
+			if (!$this->configured['activated']) {
+				add_site_option('pt_wp_discourse_sso_activated', TRUE);
 			}
 			return true;
 		} else {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Get nonce out of original payload
 	 * @param  [type] $payload [description]
@@ -314,45 +323,45 @@ class WP_Discourse_SSO {
 		$payload = urldecode($payload);
 		$query = array();
 		parse_str(base64_decode($payload), $query);
-		if(isset($query["nonce"])) {
+		if (isset($query["nonce"])) {
 			return $query["nonce"];
 		} else {
 			throw new Exception("Nonce not found in payload!");
 		}
 	}
-	
+
 	/**
 	 * Create a login string to authenticate with Discourse
 	 * @param  [type] $params [description]
 	 * @return [type]         [description]
 	 */
 	public function buildLoginString($params) {
-		if(!isset($params["external_id"])) {
+		if (!isset($params["external_id"])) {
 			throw new Exception("Missing required parameter 'external_id'");
 		}
-		if(!isset($params["nonce"])) {
+		if (!isset($params["nonce"])) {
 			throw new Exception("Missing required parameter 'nonce'");
 		}
-		if(!isset($params["email"])) {
+		if (!isset($params["email"])) {
 			throw new Exception("Missing required parameter 'email'");
 		}
 		$payload = base64_encode(http_build_query($params));
 		$sig = hash_hmac("sha256", $payload, $this->sso_secret);
-		
+
 		return http_build_query(array("sso" => $payload, "sig" => $sig));
 	}
 
-	private function cleansePayload($p){
-		return str_replace( '%0A', '%0B', $p );
+	private function cleansePayload($p) {
+		return str_replace('%0A', '%0B', $p);
 	}
 
-	private function restorePayload($p){
-		return urldecode( str_replace( '%0B', '%0A', urlencode( $p ) ) );
+	private function restorePayload($p) {
+		return urldecode(str_replace('%0B', '%0A', urlencode($p)));
 	}
-	
+
 	private function get_avatar_url($user_id) {
 		$avatar = get_avatar($user_id);
-		if(preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
+		if (preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
 			return utf8_uri_encode($matches[1]);
 	}
 
@@ -362,75 +371,116 @@ class WP_Discourse_SSO {
 	 */
 	public function interceptSSORequest() {
 
-		if( isset( $_GET['sso'] ) && isset( $_GET['sig'] ) ) {
+		if (isset($_GET['sso']) && isset($_GET['sig'])) {
 
 			$varsso = $_GET['sso'];
 			$varsig = $_GET['sig'];
 
-			if( ! $this->validate( $varsso, $varsig ) ) {
+			if (!$this->validate($varsso, $varsig)) {
 				//return;
 			}
-			
+
 			// Check to see whether the user is logged in or not
-			if ( ! is_user_logged_in() ) {
+			if (!is_user_logged_in()) {
 
 				// Preserve sso and sig parameters
-				$redirect = add_query_arg( array( 'sso' => urlencode( $varsso ), 'sig' => urlencode( $varsig ) ) );
-				
+				$redirect = add_query_arg(array('sso' => urlencode($varsso), 'sig' => urlencode($varsig)));
+
 				// Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
-				$redirect = $this->cleansePayload( $redirect );
+				$redirect = $this->cleansePayload($redirect);
 
 				// Build login URL
-				$login = wp_login_url( esc_url_raw( $redirect ) );
+				$login = wp_login_url(esc_url_raw($redirect));
 
 				// Redirect to login
-				wp_redirect( $login );
+				wp_redirect($login);
 				exit;
 
-			}
-
-			// Logged in to WordPress, now try to log in to Discourse with WordPress user information
+			} // Logged in to WordPress, now try to log in to Discourse with WordPress user information
 			else {
-
-				$ssopayload = $this->restorePayload( $_GET['sso'] );
-				$sigpayload = $_GET['sig'];
-
-				if ( ! ( $this->validate( $ssopayload, $sigpayload ) ) ) {
-					
-					// Error message
-					echo( 'Invalid request.' );
-					
-					// Terminate
-					exit;
-
+				$allowedToLogin = true;
+				if (is_plugin_active('membermouse/index.php')) {
+					if (pt_wp_sso_get_option('block_membermouse_free', 'pt_wp_sso_mm_settings') == 'on') {
+						if (mm_member_decision(array("isFree" => "true"))) {
+							$allowedToLogin = false;
+						}
+					}
 				}
 
-				// Nonce    
-				$nonce = $this->getNonce( $ssopayload );
+				if ($allowedToLogin) {
+					$ssopayload = $this->restorePayload($_GET['sso']);
+					$sigpayload = $_GET['sig'];
 
-				$current_user = wp_get_current_user();
+					if (!($this->validate($ssopayload, $sigpayload))) {
 
-				// Map information
-				$params = array(
-					'nonce' => $nonce,
-					'name' => $current_user->display_name,
-					'username' => $current_user->user_login,
-					'email' => $current_user->user_email,
-					'about_me' => $current_user->description,
-					'external_id' => $current_user->ID,
-					'avatar_url' => self::get_avatar_url($current_user->ID)
-				);
+						// Error message
+						echo('Invalid request.');
 
-				// Build login string
-				$q = $this->buildLoginString( $params );
+						// Terminate
+						exit;
 
-				// Redirect back to Discourse
-				wp_redirect( $this->discourse_url . '/session/sso_login?' . $q );
+					}
+
+					// Nonce
+					$nonce = $this->getNonce($ssopayload);
+
+					$current_user = wp_get_current_user();
+
+					// Map information
+					$params = array(
+						'nonce' => $nonce,
+						'name' => $current_user->display_name,
+						'username' => $current_user->user_login,
+						'email' => $current_user->user_email,
+						'about_me' => $current_user->description,
+						'external_id' => $current_user->ID,
+						'avatar_url' => self::get_avatar_url($current_user->ID)
+					);
+
+					// Build login string
+					$q = $this->buildLoginString($params);
+
+					// Redirect back to Discourse
+					wp_redirect($this->discourse_url . '/session/sso_login?' . $q);
+				} else {
+					//redirect to home
+					wp_redirect(home_url());
+				}
 
 				exit;
 
 			}
 		}
+	}
+
+	//If sync logout is enabled, we need to find the user id, then log that user out of discourse.
+	public function interceptLogout() {
+		if (pt_wp_sso_get_option('sync_logout', 'pt_wp_sso_settings') == 'on') {
+			$api_key = pt_wp_sso_get_option('api_key', 'pt_wp_sso_settings');
+			$api_username = pt_wp_sso_get_option('api_username', 'pt_wp_sso_settings');
+
+			if (NULL != $api_key && NULL != $api_username) {
+				$userinfo = wp_get_current_user();
+
+				$params = '?api_key=' . $api_key . '&api_username=' . $api_username;
+				$get_url = $this->discourse_url . '/users/by-external/' . $userinfo->ID . '.json' . $params;
+
+				//First Talk to Discourse and get Discourse ID
+				$response = wp_safe_remote_get($get_url);
+
+				if (is_array($response) && !is_wp_error($response)) {
+					$body = json_decode($response['body'], true);
+					$id = $body['user']['id'];
+					if (NULL != $id) {
+						//fire the logout trigger
+						$post_url = $this->discourse_url . '/admin/users/' . $id . '/log_out' . $params;
+						$response = wp_safe_remote_post($post_url);
+					}
+				}
+			}
+
+		}
+
 	}
 
 }

--- a/public/class-pt-wp-discourse-sso.php
+++ b/public/class-pt-wp-discourse-sso.php
@@ -19,469 +19,419 @@
  */
 class WP_Discourse_SSO {
 
-    public $configured = array();
-    private $sso_secret;
-    public $discourse_url;
-    public $admin_url;
+	public $configured = array();
+	private $sso_secret;
+	public $discourse_url;
+	public $admin_url;
 
-    /**
-     * Plugin version, used for cache-busting of style and script file references.
-     *
-     * @since   0.1
-     *
-     * @var     string
-     */
-    const VERSION = PT_WP_DISCOURSE_SSO_VERSION;
+	/**
+	 * Plugin version, used for cache-busting of style and script file references.
+	 *
+	 * @since   0.1
+	 *
+	 * @var     string
+	 */
+	const VERSION = PT_WP_DISCOURSE_SSO_VERSION;
 
-    /**
-     * Unique identifier
-     *
-     *
-     * The variable name is used as the text domain when internationalizing strings
-     * of text. Its value should match the Text Domain file header in the main
-     * plugin file.
-     *
-     * @since    0.1
-     *
-     * @var      string
-     */
-    protected $plugin_slug = 'pt-wp-discourse-sso';
+	/**
+	 * Unique identifier
+	 *
+	 *
+	 * The variable name is used as the text domain when internationalizing strings
+	 * of text. Its value should match the Text Domain file header in the main
+	 * plugin file.
+	 *
+	 * @since    0.1
+	 *
+	 * @var      string
+	 */
+	protected $plugin_slug = 'pt-wp-discourse-sso';
 
-    /**
-     * Instance of this class.
-     *
-     * @since    0.1
-     *
-     * @var      object
-     */
-    protected static $instance = null;
+	/**
+	 * Instance of this class.
+	 *
+	 * @since    0.1
+	 *
+	 * @var      object
+	 */
+	protected static $instance = null;
 
-    /**
-     * Initialize the plugin by setting localization and loading public scripts
-     * and styles.
-     *
-     * @since     0.1
-     */
-    private function __construct() {
+	/**
+	 * Initialize the plugin by setting localization and loading public scripts
+	 * and styles.
+	 *
+	 * @since     0.1
+	 */
+	private function __construct() {
 
-        // Activate plugin when new blog is added
-        add_action('wpmu_new_blog', array($this, 'activate_new_site'));
+		// Activate plugin when new blog is added
+		add_action( 'wpmu_new_blog', array( $this, 'activate_new_site' ) );
 
-        require_once(PT_WP_DISCOURSE_SSO_DIR . 'public/includes/helpers.php');
+		require_once(PT_WP_DISCOURSE_SSO_DIR.'public/includes/helpers.php');
 
-        $this->check_configuration();
+		$this->check_configuration();
 
-        $this->admin_url = admin_url('options-general.php?page=wp-sso-settings');
+		$this->admin_url = admin_url('options-general.php?page=wp-sso-settings');
 
-        add_action('init', array($this, 'interceptSSORequest'));
+		add_action( 'init', array( $this, 'interceptSSORequest' ) );
 
-        add_action('clear_auth_cookie', array($this, 'interceptLogout'));
+	}
 
-    }
+	private function check_configuration() {
+		$this->configured['all'] = FALSE;
+		$this->configured['secret'] = FALSE;
+		$this->configured['discourse_url'] = FALSE;
+		$this->configured['activated'] = FALSE;
 
-    private function check_configuration() {
-        $this->configured['all'] = FALSE;
-        $this->configured['secret'] = FALSE;
-        $this->configured['discourse_url'] = FALSE;
-        $this->configured['activated'] = FALSE;
+		if ( get_site_option( 'pt_wp_discourse_sso_activated' ) ) {
+			$this->configured['activated'] = TRUE;
+		}
+		
+		if ( NULL != pt_wp_sso_get_option('secret_key','pt_wp_sso_settings') ) {
+			$this->configured['secret'] = TRUE;
+			$this->sso_secret = pt_wp_sso_get_option('secret_key','pt_wp_sso_settings');
+		}
 
-        if (get_site_option('pt_wp_discourse_sso_activated')) {
-            $this->configured['activated'] = TRUE;
-        }
+		if ( NULL != pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings') ) {
+			$this->configured['discourse_url'] = TRUE;
+			$this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url','pt_wp_sso_settings'),'/');
+		}
 
-        if (NULL != pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings')) {
-            $this->configured['secret'] = TRUE;
-            $this->sso_secret = pt_wp_sso_get_option('secret_key', 'pt_wp_sso_settings');
-        }
+		// Make sure the plugin is configured
+		if ( $this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated'] ) {
+			$this->configured['all'] = TRUE;
+		}
 
-        if (NULL != pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings')) {
-            $this->configured['discourse_url'] = TRUE;
-            $this->discourse_url = rtrim(pt_wp_sso_get_option('discourse_url', 'pt_wp_sso_settings'), '/');
-        }
+		if ( ! $this->configured['all'] ) {
+			add_action( 'admin_notices', array( $this, 'render_admin_notice' ) );
+		}
 
-        // Make sure the plugin is configured
-        if ($this->configured['secret'] && $this->configured['discourse_url'] && $this->configured['activated']) {
-            $this->configured['all'] = TRUE;
-        }
+	}
 
-        if (!$this->configured['all']) {
-            add_action('admin_notices', array($this, 'render_admin_notice'));
-        }
-
-    }
-
-    public function render_admin_notice() {
-        ?>
-        <div class="error">
-            <h4>Setting up your WP + Discourse SSO connection is easy!</h4>
-
-            <p>
-            <ol>
-                <li><?php echo($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of
-                    characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings
-                        page</a>.<?php echo($this->configured['secret'] ? '</s>' : ''); ?></li>
-                <li><?php echo($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL
-                    (http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings
-                        page</a>.<?php echo($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
-                <li><?php echo($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This
-                        message will go away once you'd validated your first SSO
-                        request)</i><?php echo($this->configured['activated'] ? '</s>' : ''); ?></li>
-            </ol>
-            </p>
-        </div>
+	public function render_admin_notice() {
+		?>
+    <div class="error">
+			<h4>Setting up your WP + Discourse SSO connection is easy!</h4>
+			<p>
+			<ol>
+				<li><?php echo ($this->configured['secret'] ? '<s>' : ''); ?>Generate or come up with a random string of characters to use as a "key." Enter it in the <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['secret'] ? '</s>' : ''); ?></li>
+				<li><?php echo ($this->configured['discourse_url'] ? '<s>' : ''); ?>Paste your Discourse URL (http://example.discourse.org) into <a href="<?php echo $this->admin_url; ?>">settings page</a>.<?php echo ($this->configured['discourse_url'] ? '</s>' : ''); ?></li>
+				<li><?php echo ($this->configured['activated'] ? '<s>' : ''); ?>Handle your first authentication. <i>(This message will go away once you'd validated your first SSO request)</i><?php echo ($this->configured['activated'] ? '</s>' : ''); ?></li>
+			</ol>
+			</p>
+    </div>
     <?php
-    }
+	}
 
-    /**
-     * Return the plugin slug.
-     *
-     * @since    0.1
-     *
-     * @return    Plugin slug variable.
-     */
-    public function get_plugin_slug() {
-        return $this->plugin_slug;
-    }
+	/**
+	 * Return the plugin slug.
+	 *
+	 * @since    0.1
+	 *
+	 * @return    Plugin slug variable.
+	 */
+	public function get_plugin_slug() {
+		return $this->plugin_slug;
+	}
 
-    /**
-     * Return an instance of this class.
-     *
-     * @since     0.1
-     *
-     * @return    object    A single instance of this class.
-     */
-    public static function get_instance() {
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since     0.1
+	 *
+	 * @return    object    A single instance of this class.
+	 */
+	public static function get_instance() {
 
-        // If the single instance hasn't been set, set it now.
-        if (null == self::$instance) {
-            self::$instance = new self;
-        }
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self;
+		}
 
-        return self::$instance;
-    }
+		return self::$instance;
+	}
 
-    /**
-     * Fired when the plugin is activated.
-     *
-     * @since    0.1
-     *
-     * @param    boolean $network_wide True if WPMU superadmin uses
-     *                                       "Network Activate" action, false if
-     *                                       WPMU is disabled or plugin is
-     *                                       activated on an individual blog.
-     */
-    public static function activate($network_wide) {
+	/**
+	 * Fired when the plugin is activated.
+	 *
+	 * @since    0.1
+	 *
+	 * @param    boolean    $network_wide    True if WPMU superadmin uses
+	 *                                       "Network Activate" action, false if
+	 *                                       WPMU is disabled or plugin is
+	 *                                       activated on an individual blog.
+	 */
+	public static function activate( $network_wide ) {
 
-        if (function_exists('is_multisite') && is_multisite()) {
+		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 
-            if ($network_wide) {
+			if ( $network_wide  ) {
 
-                // Get all blog ids
-                $blog_ids = self::get_blog_ids();
+				// Get all blog ids
+				$blog_ids = self::get_blog_ids();
 
-                foreach ($blog_ids as $blog_id) {
+				foreach ( $blog_ids as $blog_id ) {
 
-                    switch_to_blog($blog_id);
-                    self::single_activate();
-                }
+					switch_to_blog( $blog_id );
+					self::single_activate();
+				}
 
-                restore_current_blog();
+				restore_current_blog();
 
-            } else {
-                self::single_activate();
-            }
+			} else {
+				self::single_activate();
+			}
 
-        } else {
-            self::single_activate();
-        }
+		} else {
+			self::single_activate();
+		}
 
-    }
+	}
 
-    /**
-     * Fired when the plugin is deactivated.
-     *
-     * @since    0.1
-     *
-     * @param    boolean $network_wide True if WPMU superadmin uses
-     *                                       "Network Deactivate" action, false if
-     *                                       WPMU is disabled or plugin is
-     *                                       deactivated on an individual blog.
-     */
-    public static function deactivate($network_wide) {
+	/**
+	 * Fired when the plugin is deactivated.
+	 *
+	 * @since    0.1
+	 *
+	 * @param    boolean    $network_wide    True if WPMU superadmin uses
+	 *                                       "Network Deactivate" action, false if
+	 *                                       WPMU is disabled or plugin is
+	 *                                       deactivated on an individual blog.
+	 */
+	public static function deactivate( $network_wide ) {
 
-        if (function_exists('is_multisite') && is_multisite()) {
+		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 
-            if ($network_wide) {
+			if ( $network_wide ) {
 
-                // Get all blog ids
-                $blog_ids = self::get_blog_ids();
+				// Get all blog ids
+				$blog_ids = self::get_blog_ids();
 
-                foreach ($blog_ids as $blog_id) {
+				foreach ( $blog_ids as $blog_id ) {
 
-                    switch_to_blog($blog_id);
-                    self::single_deactivate();
+					switch_to_blog( $blog_id );
+					self::single_deactivate();
 
-                }
+				}
 
-                restore_current_blog();
+				restore_current_blog();
 
-            } else {
-                self::single_deactivate();
-            }
+			} else {
+				self::single_deactivate();
+			}
 
-        } else {
-            self::single_deactivate();
-        }
+		} else {
+			self::single_deactivate();
+		}
 
-    }
+	}
 
-    /**
-     * Fired when a new site is activated with a WPMU environment.
-     *
-     * @since    0.1
-     *
-     * @param    int $blog_id ID of the new blog.
-     */
-    public function activate_new_site($blog_id) {
+	/**
+	 * Fired when a new site is activated with a WPMU environment.
+	 *
+	 * @since    0.1
+	 *
+	 * @param    int    $blog_id    ID of the new blog.
+	 */
+	public function activate_new_site( $blog_id ) {
 
-        if (1 !== did_action('wpmu_new_blog')) {
-            return;
-        }
+		if ( 1 !== did_action( 'wpmu_new_blog' ) ) {
+			return;
+		}
 
-        switch_to_blog($blog_id);
-        self::single_activate();
-        restore_current_blog();
+		switch_to_blog( $blog_id );
+		self::single_activate();
+		restore_current_blog();
 
-    }
+	}
 
-    /**
-     * Get all blog ids of blogs in the current network that are:
-     * - not archived
-     * - not spam
-     * - not deleted
-     *
-     * @since    0.1
-     *
-     * @return   array|false    The blog ids, false if no matches.
-     */
-    private static function get_blog_ids() {
+	/**
+	 * Get all blog ids of blogs in the current network that are:
+	 * - not archived
+	 * - not spam
+	 * - not deleted
+	 *
+	 * @since    0.1
+	 *
+	 * @return   array|false    The blog ids, false if no matches.
+	 */
+	private static function get_blog_ids() {
 
-        global $wpdb;
+		global $wpdb;
 
-        // get an array of blog ids
-        $sql = "SELECT blog_id FROM $wpdb->blogs
+		// get an array of blog ids
+		$sql = "SELECT blog_id FROM $wpdb->blogs
 			WHERE archived = '0' AND spam = '0'
 			AND deleted = '0'";
 
-        return $wpdb->get_col($sql);
+		return $wpdb->get_col( $sql );
 
-    }
+	}
 
-    /**
-     * Fired for each blog when the plugin is activated.
-     *
-     * @since    0.1
-     */
-    private static function single_activate() {
-        // @TODO: Define activation functionality here
-    }
+	/**
+	 * Fired for each blog when the plugin is activated.
+	 *
+	 * @since    0.1
+	 */
+	private static function single_activate() {
+		// @TODO: Define activation functionality here
+	}
 
-    /**
-     * Fired for each blog when the plugin is deactivated.
-     *
-     * @since    0.1
-     */
-    private static function single_deactivate() {
-        // @TODO: Define deactivation functionality here
-    }
+	/**
+	 * Fired for each blog when the plugin is deactivated.
+	 *
+	 * @since    0.1
+	 */
+	private static function single_deactivate() {
+		// @TODO: Define deactivation functionality here
+	}
 
-    /**
-     * Validate the SSO payload
-     * @param  [type] $payload [description]
-     * @param  [type] $sig     [description]
-     * @return [type]          [description]
-     */
-    public function validate($payload, $sig) {
+	/**
+	 * Validate the SSO payload
+	 * @param  [type] $payload [description]
+	 * @param  [type] $sig     [description]
+	 * @return [type]          [description]
+	 */
+	public function validate($payload, $sig) {
 
-        $payload = urldecode($payload);
-        if (hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
-            if (!$this->configured['activated']) {
-                add_site_option('pt_wp_discourse_sso_activated', TRUE);
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
+		$payload = urldecode($payload);
+		if(hash_hmac("sha256", $payload, $this->sso_secret) === $sig) {
+			if( !$this->configured['activated'] ){
+				add_site_option( 'pt_wp_discourse_sso_activated', TRUE );
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	/**
+	 * Get nonce out of original payload
+	 * @param  [type] $payload [description]
+	 * @return [type]          [description]
+	 */
+	public function getNonce($payload) {
+		$payload = urldecode($payload);
+		$query = array();
+		parse_str(base64_decode($payload), $query);
+		if(isset($query["nonce"])) {
+			return $query["nonce"];
+		} else {
+			throw new Exception("Nonce not found in payload!");
+		}
+	}
+	
+	/**
+	 * Create a login string to authenticate with Discourse
+	 * @param  [type] $params [description]
+	 * @return [type]         [description]
+	 */
+	public function buildLoginString($params) {
+		if(!isset($params["external_id"])) {
+			throw new Exception("Missing required parameter 'external_id'");
+		}
+		if(!isset($params["nonce"])) {
+			throw new Exception("Missing required parameter 'nonce'");
+		}
+		if(!isset($params["email"])) {
+			throw new Exception("Missing required parameter 'email'");
+		}
+		$payload = base64_encode(http_build_query($params));
+		$sig = hash_hmac("sha256", $payload, $this->sso_secret);
+		
+		return http_build_query(array("sso" => $payload, "sig" => $sig));
+	}
 
-    /**
-     * Get nonce out of original payload
-     * @param  [type] $payload [description]
-     * @return [type]          [description]
-     */
-    public function getNonce($payload) {
-        $payload = urldecode($payload);
-        $query = array();
-        parse_str(base64_decode($payload), $query);
-        if (isset($query["nonce"])) {
-            return $query["nonce"];
-        } else {
-            throw new Exception("Nonce not found in payload!");
-        }
-    }
+	private function cleansePayload($p){
+		return str_replace( '%0A', '%0B', $p );
+	}
 
-    /**
-     * Create a login string to authenticate with Discourse
-     * @param  [type] $params [description]
-     * @return [type]         [description]
-     */
-    public function buildLoginString($params) {
-        if (!isset($params["external_id"])) {
-            throw new Exception("Missing required parameter 'external_id'");
-        }
-        if (!isset($params["nonce"])) {
-            throw new Exception("Missing required parameter 'nonce'");
-        }
-        if (!isset($params["email"])) {
-            throw new Exception("Missing required parameter 'email'");
-        }
-        $payload = base64_encode(http_build_query($params));
-        $sig = hash_hmac("sha256", $payload, $this->sso_secret);
+	private function restorePayload($p){
+		return urldecode( str_replace( '%0B', '%0A', urlencode( $p ) ) );
+	}
+	
+	private function get_avatar_url($user_id) {
+		$avatar = get_avatar($user_id);
+		if(preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
+			return utf8_uri_encode($matches[1]);
+	}
 
-        return http_build_query(array("sso" => $payload, "sig" => $sig));
-    }
+	/**
+	 * Callback function to intercept and validate SSO requests
+	 * @return [type] [description]
+	 */
+	public function interceptSSORequest() {
 
-    private function cleansePayload($p) {
-        return str_replace('%0A', '%0B', $p);
-    }
+		if( isset( $_GET['sso'] ) && isset( $_GET['sig'] ) ) {
 
-    private function restorePayload($p) {
-        return urldecode(str_replace('%0B', '%0A', urlencode($p)));
-    }
+			$varsso = $_GET['sso'];
+			$varsig = $_GET['sig'];
 
-    private function get_avatar_url($user_id) {
-        $avatar = get_avatar($user_id);
-        if (preg_match("/src=['\"](.*?)['\"]/i", $avatar, $matches))
-            return utf8_uri_encode($matches[1]);
-    }
+			if( ! $this->validate( $varsso, $varsig ) ) {
+				//return;
+			}
+			
+			// Check to see whether the user is logged in or not
+			if ( ! is_user_logged_in() ) {
 
-    /**
-     * Callback function to intercept and validate SSO requests
-     * @return [type] [description]
-     */
-    public function interceptSSORequest() {
+				// Preserve sso and sig parameters
+				$redirect = add_query_arg( array( 'sso' => urlencode( $varsso ), 'sig' => urlencode( $varsig ) ) );
+				
+				// Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
+				$redirect = $this->cleansePayload( $redirect );
 
-        if (isset($_GET['sso']) && isset($_GET['sig'])) {
+				// Build login URL
+				$login = wp_login_url( esc_url_raw( $redirect ) );
 
-            $varsso = $_GET['sso'];
-            $varsig = $_GET['sig'];
+				// Redirect to login
+				wp_redirect( $login );
+				exit;
 
-            if (!$this->validate($varsso, $varsig)) {
-                //return;
-            }
+			}
 
-            // Check to see whether the user is logged in or not
-            if (!is_user_logged_in()) {
+			// Logged in to WordPress, now try to log in to Discourse with WordPress user information
+			else {
 
-                // Preserve sso and sig parameters
-                $redirect = add_query_arg(array('sso' => urlencode($varsso), 'sig' => urlencode($varsig)));
+				$ssopayload = $this->restorePayload( $_GET['sso'] );
+				$sigpayload = $_GET['sig'];
 
-                // Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
-                $redirect = $this->cleansePayload($redirect);
+				if ( ! ( $this->validate( $ssopayload, $sigpayload ) ) ) {
+					
+					// Error message
+					echo( 'Invalid request.' );
+					
+					// Terminate
+					exit;
 
-                // Build login URL
-                $login = wp_login_url(esc_url_raw($redirect));
+				}
 
-                // Redirect to login
-                wp_redirect($login);
-                exit;
+				// Nonce    
+				$nonce = $this->getNonce( $ssopayload );
 
-            } // Logged in to WordPress, now try to log in to Discourse with WordPress user information
-            else {
-                $allowedToLogin = true;
-                if (is_plugin_active('membermouse/index.php')) {
-                    if (pt_wp_sso_get_option('block_membermouse_free', 'pt_wp_sso_mm_settings') == 'on') {
-                        if (mm_member_decision(array("isFree" => "true"))) {
-                            $allowedToLogin = false;
-                        }
-                    }
-                }
+				$current_user = wp_get_current_user();
 
-                if ($allowedToLogin) {
-                    $ssopayload = $this->restorePayload($_GET['sso']);
-                    $sigpayload = $_GET['sig'];
+				// Map information
+				$params = array(
+					'nonce' => $nonce,
+					'name' => $current_user->display_name,
+					'username' => $current_user->user_login,
+					'email' => $current_user->user_email,
+					'about_me' => $current_user->description,
+					'external_id' => $current_user->ID,
+					'avatar_url' => self::get_avatar_url($current_user->ID)
+				);
 
-                    if (!($this->validate($ssopayload, $sigpayload))) {
+				// Build login string
+				$q = $this->buildLoginString( $params );
 
-                        // Error message
-                        echo('Invalid request.');
+				// Redirect back to Discourse
+				wp_redirect( $this->discourse_url . '/session/sso_login?' . $q );
 
-                        // Terminate
-                        exit;
+				exit;
 
-                    }
-
-                    // Nonce
-                    $nonce = $this->getNonce($ssopayload);
-
-                    $current_user = wp_get_current_user();
-
-                    // Map information
-                    $params = array(
-                        'nonce' => $nonce,
-                        'name' => $current_user->display_name,
-                        'username' => $current_user->user_login,
-                        'email' => $current_user->user_email,
-                        'about_me' => $current_user->description,
-                        'external_id' => $current_user->ID,
-                        'avatar_url' => self::get_avatar_url($current_user->ID)
-                    );
-
-                    // Build login string
-                    $q = $this->buildLoginString($params);
-
-                    // Redirect back to Discourse
-                    wp_redirect($this->discourse_url . '/session/sso_login?' . $q);
-                } else {
-                    //redirect to home
-                    wp_redirect(home_url());
-                }
-
-                exit;
-
-            }
-        }
-    }
-
-    //If sync logout is enabled, we need to find the user id, then log that user out of discourse.
-    public function interceptLogout() {
-        if (pt_wp_sso_get_option('sync_logout', 'pt_wp_sso_settings') == 'on') {
-            $api_key = pt_wp_sso_get_option('api_key', 'pt_wp_sso_settings');
-            $api_username = pt_wp_sso_get_option('api_username', 'pt_wp_sso_settings');
-
-            if (NULL != $api_key && NULL != $api_username) {
-                $userinfo = wp_get_current_user();
-
-                $params = '?api_key=' . $api_key . '&api_username=' . $api_username;
-                $get_url = $this->discourse_url . '/users/by-external/' . $userinfo->ID . '.json' . $params;
-
-                //First Talk to Discourse and get Discourse ID
-                $response = wp_safe_remote_get($get_url);
-
-                if ( is_array( $response ) && ! is_wp_error( $response ) ) {
-                    $body = json_decode($response['body'], true);
-                    $id = $body['user']['id'];
-                    if (NULL != $id) {
-                        //fire the logout trigger
-                        $post_url =  $this->discourse_url . '/admin/users/' . $id . '/log_out'. $params;
-                        $response = wp_safe_remote_post($post_url);
-                    }
-                }
-            }
-
-        }
-
-    }
+			}
+		}
+	}
 
 }
 


### PR DESCRIPTION
If a user logs out of the main WordPress site, this doesn't necessarily log them out of the Discourse SSO installation. This was causing some confusion for our users when they logged out of one system, and then clicked on links in the community forum that went to the main site, which then asked them to login again. So added the logout trigger, which requires an Admin API key/username.

Also added some basic MemberMouse support to exclude free members from accessing the discourse server. This checks for plugin existence before being activated.

Tried to keep format diff spam down, didn't work out so well, sorry about that :)

Cheers.
