### PR TITLE
Change 'about_me' parameter to 'bio'

### DIFF
--- a/public/class-pt-wp-discourse-sso.php
+++ b/public/class-pt-wp-discourse-sso.php
@@ -432,7 +432,7 @@ class WP_Discourse_SSO {
 						'name' => $current_user->display_name,
 						'username' => $current_user->user_login,
 						'email' => $current_user->user_email,
-						'about_me' => $current_user->description,
+						'bio' => $current_user->description,
 						'external_id' => $current_user->ID,
 						'avatar_url' => self::get_avatar_url($current_user->ID)
 					);


### PR DESCRIPTION
The `about_me` parameter was never implemented by Discourse. The `bio` parameter should be used instead. More details at https://meta.discourse.org/t/sso-what-is-the-use-of-the-about-me-attribute/36235/8